### PR TITLE
Resolve Build and Runtime Issues on Windows with MSVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ results/many-shapes-experiment/**/*.obj
 results/**/*.obj
 results/**/*.ply
 results/**/*.npy
+results/**/*.eps
+results/**/*.pdf
+results/**/*.png
 scripts/silvias-debug-script.py
 paper/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,17 @@
 cmake_minimum_required(VERSION 3.10)
 
+#https://discourse.cmake.org/t/msvc-runtime-library-completely-ignored/10004
+cmake_policy(SET CMP0091 NEW)
+
 project(Bindings
 	DESCRIPTION
 		"Python bindings"
 )
+
+# MSVC needs explicit configuration for multithreading
+# Select a multi-threaded statically-linked runtime library
+# 	with or without debug information depending on the configuration
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/scripts/context.py
+++ b/scripts/context.py
@@ -17,16 +17,16 @@ if os_name == "Darwin":
 
     # Check if the macOS version is less than 14
     if os_version and os_version < "14":
-        sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build-studio')))
+        sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../build-studio')))
     else:
-        sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build')))
+        sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../build')))
 elif os_name == "Windows":
     # For Windows systems
-    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build/Debug')))
-    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build/Release')))
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../build/Debug')))
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../build/Release')))
 else:
     # For other systems
-    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build')))
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../build')))
 import rfta_bindings
 
 import matplotlib.pyplot as plt

--- a/scripts/context.py
+++ b/scripts/context.py
@@ -17,12 +17,16 @@ if os_name == "Darwin":
 
     # Check if the macOS version is less than 14
     if os_version and os_version < "14":
-        sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../build-studio')))
+        sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build-studio')))
     else:
-        sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../build')))
+        sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build')))
+elif os_name == "Windows":
+    # For Windows systems
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build/Debug')))
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build/Release')))
 else:
-    # For non-macOS systems
-    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../build')))
+    # For other systems
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build')))
 import rfta_bindings
 
 import matplotlib.pyplot as plt

--- a/scripts/fig_collision.py
+++ b/scripts/fig_collision.py
@@ -123,7 +123,8 @@ if args.metrics:
     # turn ts_gt into binary "hit / no hit" (it is inf if no hit)
     ts_gt_bool = np.isfinite(ts_gt)
 
-    meshes = ["marching_cubes", "ndc", "ours"]
+    # meshes = ["marching_cubes", "ndc", "ours"]
+    meshes = ["marching_cubes", "ours"]
     for mesh in meshes:
         # load
         filename = results_path + f"/{mesh}.obj"

--- a/src/cpp/fine_tune_point_cloud_iter.cpp
+++ b/src/cpp/fine_tune_point_cloud_iter.cpp
@@ -1,5 +1,9 @@
 #include "fine_tune_point_cloud_iter.h"
 
+#define _USE_MATH_DEFINES
+#include <cmath>
+#include <numeric>
+
 #include <random>
 #include <iostream>
 #include <algorithm>

--- a/src/cpp/locally_make_feasible.cpp
+++ b/src/cpp/locally_make_feasible.cpp
@@ -1,5 +1,7 @@
 #include "locally_make_feasible.h"
 
+#include <numeric>
+
 #include <random>
 #include <iostream>
 #include <algorithm>

--- a/src/python/rfta/__init__.py
+++ b/src/python/rfta/__init__.py
@@ -10,8 +10,12 @@ if os_name == "Darwin":
         sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build-studio')))
     else:
         sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build')))
+elif os_name == "Windows":
+    # For Windows systems
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build/Debug')))
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build/Release')))
 else:
-    # For non-macOS systems
+    # For other systems
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build')))
     
 from .reach_for_the_arcs import reach_for_the_arcs

--- a/src/python/rfta/fine_tune_point_cloud.py
+++ b/src/python/rfta/fine_tune_point_cloud.py
@@ -14,8 +14,12 @@ if os_name == "Darwin":
         sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build-studio')))
     else:
         sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build')))
+elif os_name == "Windows":
+    # For Windows systems
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build/Debug')))
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build/Release')))
 else:
-    # For non-macOS systems
+    # For other systems
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build')))
 from rfta_bindings import _fine_tune_point_cloud_iter_cpp_impl
 

--- a/src/python/rfta/locally_make_feasible.py
+++ b/src/python/rfta/locally_make_feasible.py
@@ -14,8 +14,12 @@ if os_name == "Darwin":
         sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build-studio')))
     else:
         sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build')))
+elif os_name == "Windows":
+    # For Windows systems
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build/Debug')))
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build/Release')))
 else:
-    # For non-macOS systems
+    # For other systems
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build')))
 import math
 from rfta_bindings import _locally_make_feasible_cpp_impl

--- a/src/python/rfta/outside_points_from_rasterization.py
+++ b/src/python/rfta/outside_points_from_rasterization.py
@@ -17,8 +17,12 @@ if os_name == "Darwin":
         sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build-studio')))
     else:
         sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build')))
+elif os_name == "Windows":
+    # For Windows systems
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build/Debug')))
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build/Release')))
 else:
-    # For non-macOS systems
+    # For other systems
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build')))
 from rfta_bindings import _outside_points_from_rasterization_cpp_impl
 

--- a/src/python/rfta/point_cloud_to_mesh.py
+++ b/src/python/rfta/point_cloud_to_mesh.py
@@ -14,8 +14,12 @@ if os_name == "Darwin":
         sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build-studio')))
     else:
         sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build')))
+elif os_name == "Windows":
+    # For Windows systems
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build/Debug')))
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build/Release')))
 else:
-    # For non-macOS systems
+    # For other systems
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../build')))
 from rfta_bindings import _point_cloud_to_mesh_cpp_impl
 

--- a/utility/aux_sample_empty_space.py
+++ b/utility/aux_sample_empty_space.py
@@ -16,6 +16,10 @@ if os_name == "Darwin":
         sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../build-studio')))
     else:
         sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../build')))
+elif os_name == "Windows":
+    # For Windows systems
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../build/Debug')))
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../build/Release')))
 else:
     # For non-macOS systems
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../build')))


### PR DESCRIPTION
## Summary

The primary modifications include adding necessary C++ macros and headers, specifying MSVC build output paths, and configuring MSVC multi-threading runtime library.

## Changes

1. **C++ Code**:
    - Added `#include <numeric>` to resolve error C2039: 'iota' is not a member of 'std'.
    - Added `#define _USE_MATH_DEFINES` and `#include <cmath>` to resolve error C2065: 'M_PI' undeclared identifier.

2. **Python Code**:
    - Added MSVC build output paths (_build/Debug_ and _build/Release_) so that Python code can locate the C++ libraries generated by MSVC.
    - In _fig\_collision.py_, remove `"ndc"` in the list `meshes` to be consistent with the above commented code.

3. **CMake Configuration**:
    - Added multi-threading runtime library configuration for MSVC in _CMakeLists.txt_ to ensure the `PoissonRecon` code runs successfully (e.g., `reset()` function in struct `Profiler`).
    - Set `CMP0091` policy to NEW to support `CMAKE_MSVC_RUNTIME_LIBRARY`.

4. **Ignoring files**
    - Ignore files with _.eps_, _.pdf_, and _.png_ extensions in the _results_ directory and its subdirectories.

## Testing

The changes were tested in the following environment:

- **Operating System**: Windows 11
- **Compiler**: MSVC 19.41.34117.0
- **IDE**: Visual Studio 17 2022
- **Build Tool**: CMake 3.27.7
- **Package Manager**: Conda 24.3.0

All Python scripts in the _scripts_ directory, except _fig_many-shapes-experiment.py_, were tested once (without `ndc`). There were several **Runtime Warnings** such as "MatrixRankWarning: Matrix is exactly singular" during the execution of some scripts, but results were generated successfully.
